### PR TITLE
feat: add full environment substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes since 1.3.0
 - chore(deps): bump to golang 1.24
+- feat: add full environment substitution
 
 # 1.3.0
 - feat: add templating command

--- a/docs/key-features-and-use-cases.md
+++ b/docs/key-features-and-use-cases.md
@@ -61,9 +61,21 @@ repositories:
 
 ### Environment variables
 
-`helm-compose` is able to inject environment variables inside your values block to deal with secrets that shouldn't be committed to your source control.
+`helm-compose` utilizes [a8m/envsubst](https://github.com/a8m/envsubst?tab=readme-ov-file#docs) to substitute environment variables inside your values block. This allows for better dealing with secrets that shouldn't be committed to your source control.
 
-Syntax: `${MY_ENV_VARIABLE}`.
+|__Expression__     | __Meaning__    |
+| ----------------- | -------------- |
+|`${var}`           | Value of var (same as `$var`)
+|`${var-$DEFAULT}`  | If var not set, evaluate expression as $DEFAULT
+|`${var:-$DEFAULT}` | If var not set or is empty, evaluate expression as $DEFAULT
+|`${var=$DEFAULT}`  | If var not set, evaluate expression as $DEFAULT
+|`${var:=$DEFAULT}` | If var not set or is empty, evaluate expression as $DEFAULT
+|`${var+$OTHER}`    | If var set, evaluate expression as $OTHER, otherwise as empty string
+|`${var:+$OTHER}`   | If var set, evaluate expression as $OTHER, otherwise as empty string
+|`$${var}`            | Escape expressions. Result will be `${var}`. 
+
+<sub>Most of the rows in this table were taken from [here](http://www.tldp.org/LDP/abs/html/refcards.html#AEN22728)</sub>
+
 
 ```bash
 export WORDPRESS_ADMIN_PASSWORD="xxx"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/a8m/envsubst v1.4.3 // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/a8m/envsubst v1.4.3 h1:kDF7paGK8QACWYaQo6KtyYBozY2jhQrTuNNuUxQkhJY=
+github.com/a8m/envsubst v1.4.3/go.mod h1:4jjHWQlZoaXPoLQUb7H2qT4iLkZDdmEQiOUogdUmqVU=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -20,12 +20,9 @@ import (
 	"math"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
-)
 
-var (
-	re = regexp.MustCompile(`\$\{(.*?)\}`)
+	"github.com/a8m/envsubst"
 )
 
 func IsDebug() bool {
@@ -69,12 +66,17 @@ func ConvertJson(obj interface{}) interface{} {
 		}
 	case string:
 		str := obj.(string)
-		matches := re.FindStringSubmatch(str)
-		for _, match := range matches {
-			str = strings.Replace(str, "${"+match+"}", os.Getenv(match), 1)
+
+		substituted, err := envsubst.String(str)
+		if err != nil {
+			if IsDebug() {
+				DebugPrint("Error while substituting environment variables for value '%s': %v", str, err)
+			}
+
+			return str
 		}
 
-		return str
+		return substituted
 	}
 	return obj
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces the capability of full environment variable substitution like in a bash script.

## Motivation and Context
At the moment the codebase only allows for matches like `${MY_ENV_VAR}` but escaping of `$` is not possible or default values like `${MY_ENV_VAR:-default}` aren't possible either.

The PR introduces the following capabilities:

|__Expression__     | __Meaning__    |
| ----------------- | -------------- |
|`${var}`           | Value of var (same as `$var`)
|`${var-$DEFAULT}`  | If var not set, evaluate expression as $DEFAULT
|`${var:-$DEFAULT}` | If var not set or is empty, evaluate expression as $DEFAULT
|`${var=$DEFAULT}`  | If var not set, evaluate expression as $DEFAULT
|`${var:=$DEFAULT}` | If var not set or is empty, evaluate expression as $DEFAULT
|`${var+$OTHER}`    | If var set, evaluate expression as $OTHER, otherwise as empty string
|`${var:+$OTHER}`   | If var set, evaluate expression as $OTHER, otherwise as empty string
|`$${var}`            | Escape expressions. Result will be `${var}`. 


Fixes: #160

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the CHANGELOG.md accordingly.
- [x] I have created a feature (non-master) branch for my PR.